### PR TITLE
DS-421 - B2B: Flow version is getting increased by 3 (It should increased by 1 only) on re-deploying the flow

### DIFF
--- a/controllers/flow.utils.controller.js
+++ b/controllers/flow.utils.controller.js
@@ -286,7 +286,7 @@ router.put('/:id/deploy', async (req, res) => {
 			await draftDoc.remove();
 		}
 
-		doc.version = oldFlowObj.version;
+		doc.version = oldFlowObj.draftVersion;
 		doc.draftVersion = null;
 		doc.status = 'Pending';
 		doc._req = req;
@@ -758,7 +758,7 @@ router.get('/:id/yamls', async (req, res) => {
 		const namespace = (config.DATA_STACK_NAMESPACE + '-' + doc.app).toLowerCase();
 		const port = 8080;
 		const name = doc.deploymentName;
-		const envKeys = ['FQDN', 'LOG_LEVEL', 'MONGO_APPCENTER_URL', 'MONGO_AUTHOR_DBNAME', 'MONGO_AUTHOR_URL', 'MONGO_LOGS_DBNAME', 'MONGO_LOGS_URL', 'MONGO_RECONN_TIME', 'MONGO_RECONN_TRIES', 'STREAMING_CHANNEL', 'STREAMING_HOST', 'STREAMING_PASS', 'STREAMING_RECONN_ATTEMPTS', 'STREAMING_RECONN_TIMEWAIT', 'STREAMING_USER', 'DATA_STACK_NAMESPACE', 'CACHE_CLUSTER', 'CACHE_HOST', 'CACHE_PORT', 'CACHE_RECONN_ATTEMPTS', 'CACHE_RECONN_TIMEWAIT_MILLI', 'RELEASE', 'TLS_REJECT_UNAUTHORIZED', 'API_REQUEST_TIMEOUT','B2B_ALLOW_NPM_INSTALL'];
+		const envKeys = ['FQDN', 'LOG_LEVEL', 'MONGO_APPCENTER_URL', 'MONGO_AUTHOR_DBNAME', 'MONGO_AUTHOR_URL', 'MONGO_LOGS_DBNAME', 'MONGO_LOGS_URL', 'MONGO_RECONN_TIME', 'MONGO_RECONN_TRIES', 'STREAMING_CHANNEL', 'STREAMING_HOST', 'STREAMING_PASS', 'STREAMING_RECONN_ATTEMPTS', 'STREAMING_RECONN_TIMEWAIT', 'STREAMING_USER', 'DATA_STACK_NAMESPACE', 'CACHE_CLUSTER', 'CACHE_HOST', 'CACHE_PORT', 'CACHE_RECONN_ATTEMPTS', 'CACHE_RECONN_TIMEWAIT_MILLI', 'RELEASE', 'TLS_REJECT_UNAUTHORIZED', 'API_REQUEST_TIMEOUT', 'B2B_ALLOW_NPM_INSTALL'];
 		const envVars = [];
 		envKeys.forEach(key => {
 			envVars.push({ name: key, value: process.env[key] });

--- a/models/flow.model.js
+++ b/models/flow.model.js
@@ -16,12 +16,8 @@ dataStackUtils.eventsUtil.setNatsClient(client);
 
 const draftDefinition = JSON.parse(JSON.stringify(definition));
 
-const schema = mongooseUtils.MakeSchema(definition, {
-	versionKey: 'version'
-});
-const draftSchema = mongooseUtils.MakeSchema(draftDefinition, {
-	versionKey: 'version'
-});
+const schema = mongooseUtils.MakeSchema(definition);
+const draftSchema = mongooseUtils.MakeSchema(draftDefinition);
 const npmLibrarySchema = mongooseUtils.MakeSchema({ _id: String }, { strict: false });
 
 schema.index({ name: 1, app: 1 }, { unique: true, sparse: true, collation: { locale: 'en_US', strength: 2 } });


### PR DESCRIPTION
This issue was caused due to the usage of the `version` field as `versionKey` in the mongoose schema. Consequently, whenever a document was saved using `doc.save()`, mongoose would inadvertently increase the version number.

To tackle this, I have eliminated version keying based on `version` field from both `flow` and `flowDraftSchema` and opted for manual versioning.